### PR TITLE
Trim commas in get_quote

### DIFF
--- a/InvestopediaApi/ita.py
+++ b/InvestopediaApi/ita.py
@@ -325,6 +325,7 @@ def get_quote(symbol):
     parsed_html = response.soup
     try:
         quote = parsed_html.find('td', attrs={'id': quote_id}).text
+        quote = quote.replace(",", "")
     except:
         return False
     return float(quote)


### PR DESCRIPTION
This fixes `get_quote` by replacing commas in `quote` with an empty string. The `get_quote` function raises a ValueError if the argument is greater than 1,000. This is because the returned value `quote` will have a comma in it, so it cannot be converted into a float.